### PR TITLE
Remove EMP from weapons

### DIFF
--- a/src/controller/fileaccess/DatabaseIniParser.java
+++ b/src/controller/fileaccess/DatabaseIniParser.java
@@ -200,11 +200,6 @@ public class DatabaseIniParser extends DatabaseParser implements Runnable
 				w.setArmourDamage(sc.nextInt());
 				w.setAccuracy(sc.nextInt());
 				w.setPowerLevel(sc.nextInt());
-
-				String emp = sc.next();
-				w.setEmpInPercent(emp.endsWith("%"));
-				w.setEmpDamage(Integer.parseInt(emp.replaceAll("%", "")));
-
 				w.addRestriction(new Restriction(sc.next().trim()));
 
 //				while (sc.hasNext())

--- a/src/model/Weapon.java
+++ b/src/model/Weapon.java
@@ -18,8 +18,6 @@ public class Weapon implements HasRace
 	private int armourDamage;
 	private int accuracy;
 	private int powerLevel;
-	private int empDamage;
-	private boolean isEmpInPercent;
 	private final ArrayList<Restriction> restrictions = new ArrayList<Restriction>();
 
 	public Weapon(String _name)
@@ -90,40 +88,6 @@ public class Weapon implements HasRace
 	public void setCost(int _cost)
 	{
 		this.cost = _cost;
-	}
-
-	/**
-	 * @return the emp
-	 */
-	public int getEmpDamage()
-	{
-		return this.empDamage;
-	}
-
-	/**
-	 * @param _emp
-	 *            the emp to set
-	 */
-	public void setEmpDamage(int _emp)
-	{
-		this.empDamage = _emp;
-	}
-
-	/**
-	 * @return the isEmpInPercent
-	 */
-	public boolean isEmpInPercent()
-	{
-		return this.isEmpInPercent;
-	}
-
-	/**
-	 * @param _isEmpInPercent
-	 *            the isEmpInPercent to set
-	 */
-	public void setEmpInPercent(boolean _isEmpInPercent)
-	{
-		this.isEmpInPercent = _isEmpInPercent;
 	}
 
 	/**

--- a/src/view/WeaponListPanel.java
+++ b/src/view/WeaponListPanel.java
@@ -24,7 +24,7 @@ public class WeaponListPanel extends ListPanelWithRaces implements ActionListene
 	{
 		// Weapon list table
 		Map<String, Weapon> weapons = Weapon.getWeapons();
-		this.createLTM(weapons.size(), 9);
+		this.createLTM(weapons.size(), 8);
 		ltm.setEditable(false);
 
 		int col = 0;
@@ -41,8 +41,6 @@ public class WeaponListPanel extends ListPanelWithRaces implements ActionListene
 		ltm.setColumnName("Accuracy", col);
 		col++;
 		ltm.setColumnName("Power Level", col);
-		col++;
-		ltm.setColumnName("EMP", col);
 		col++;
 		ltm.setColumnName("Restrictions", col);
 
@@ -62,8 +60,6 @@ public class WeaponListPanel extends ListPanelWithRaces implements ActionListene
 			ltm.setValueAt(w.getAccuracy(), row, col);
 			col++;
 			ltm.setValueAt(w.getPowerLevel(), row, col);
-			col++;
-			ltm.setValueAt(w.getEmpDamage() + (w.isEmpInPercent() ? "%" : ""), row, col);
 			col++;
 			String rString = "";
 			for (Restriction r : w.getRestrictions()) {


### PR DESCRIPTION
This change is needed for compatibility with SMR Sectors File v1.07,
which removed the vestigial "EMP" field from the Weapon specification.